### PR TITLE
fix cover image on user page

### DIFF
--- a/apps/web/src/pages/User/User.tsx
+++ b/apps/web/src/pages/User/User.tsx
@@ -68,8 +68,6 @@ const User = () => {
     );
   }
 
-  console.log({ data });
-
   return (
     <div className='bg-black'>
       <div className='relative flex flex-col items-center lg:items-start'>

--- a/apps/web/src/pages/User/User.tsx
+++ b/apps/web/src/pages/User/User.tsx
@@ -68,12 +68,14 @@ const User = () => {
     );
   }
 
+  console.log({ data });
+
   return (
     <div className='bg-black'>
       <div className='relative flex flex-col items-center lg:items-start'>
         <Image
           className='w-full h-[320px] object-cover'
-          src={data?.user?.cover ?? COVER_PLACEHOLDER}
+          src={data?.user?.cover || COVER_PLACEHOLDER}
           alt={user?.name}
           width={1000}
           height={1000}


### PR DESCRIPTION
# Description

Previously the image would not show since we have no cover image selected. Now it shows default placeholder image

![image](https://user-images.githubusercontent.com/16122132/235102203-5d1e7aba-cd42-47d6-bcfe-48b0ebc47bea.png)


## Type of change

Please delete options that are not relevant.

-  Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Showcase

Please attach a picture or a video showing what this change does.
