### PR TITLE
feat: add background overlay

### DIFF
--- a/apps/web/src/pages/Home/Home.tsx
+++ b/apps/web/src/pages/Home/Home.tsx
@@ -172,10 +172,10 @@ function Home() {
         </Link>
       </div>
       <div
-        className='-mx-28 flex h-[640px] items-end bg-cover bg-center max-lg:-mx-[30px] max-lg:items-center'
+        className='relative -mx-28 flex h-[640px] items-end bg-cover bg-center  max-lg:-mx-[30px] max-lg:items-center'
         style={{ backgroundImage: `url(${coverProject?.preview})` }}
       >
-        <div className='flex flex-col gap-[30px] py-16 px-28 max-lg:px-[30px]'>
+        <div className='z-10 flex flex-col gap-[30px] py-16 px-28 max-lg:px-[30px]'>
           <div className='flex w-fit items-center gap-3 rounded-lg bg-grey-dark px-5 py-[10px]'>
             <Image
               className='rounded-full'
@@ -195,6 +195,7 @@ function Home() {
             </Button>
           </Link>
         </div>
+        <div className='absolute top-0 left-0 h-full w-full bg-black opacity-60' />
       </div>
       <div className='py-20 max-lg:pt-10'>
         <div className='mb-10 flex flex-col gap-[10px]'>


### PR DESCRIPTION
# Description

Added a black layer between the background image and text content. This way the image colors don't take over the text content entirely. 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Showcase

Please attach a picture or a video showing what this change does.

![image](https://github.com/ivanms1/project-shelf/assets/45031293/a5b7d23d-a7fd-4b7b-9a7f-5238e23c614f)

